### PR TITLE
Throw an exception when not decoding

### DIFF
--- a/UPNG.js
+++ b/UPNG.js
@@ -324,6 +324,9 @@ UPNG.decode = function(buff)
 	while(true)
 	{
 		var len = bin.readUint(data, offset);  offset += 4;
+		
+		if	( isNaN(len) ) { throw "Invalid PNG format. Unable to decode"; }
+		
 		var type = bin.readASCII(data, offset, 4);  offset += 4;
 		//log(offset, len, type);
 


### PR DESCRIPTION
When trying to decode a file that is not a png, `decode` will remain in an infinite loop due to `while(true)` and the fact that  `var len = bin.readUint(data, offset)` gives `NaN`. Then, the method continues to read the file, adding `4` to the offset but actually adding 4 to `NaN`, which gives `NaN`, and so on.
The quick fix is to throw an exception whenever the `len` is `NaN` because we know it would then be trapped.