### PR TITLE
Fix UZIP detection

### DIFF
--- a/UPNG.js
+++ b/UPNG.js
@@ -799,7 +799,7 @@ UPNG.encode._filterZero = function(img,h,bpp,bpl,data, filter, levelZero)
 	var opts;  if(levelZero) opts={level:0};
 	
 	
-	var CMPR = (data.length>10e6 && UZIP!=null) ? UZIP : pako;
+	var CMPR = (data.length>10e6 && typeof UZIP !== "undefined") ? UZIP : pako;
 	
 	var time = Date.now();
 	for(var i=0; i<ftry.length; i++) {


### PR DESCRIPTION
The current way of detecting UZIP causes error: `UZIP is not defined`, this is a fix for it.